### PR TITLE
Fix bug in object casting PHP <= 5.1.

### DIFF
--- a/class.cast-to-type-php4.php
+++ b/class.cast-to-type-php4.php
@@ -420,21 +420,11 @@ if ( ! class_exists( 'CastToType' ) ) {
 			}
 
 			if ( $allow_empty === false ) {
-				if ( version_compare( PHP_VERSION, '5.0.0', '>=' ) === true ) {
-					$obj = new ReflectionObject( $value );
-					if ( ( count( $obj->getMethods() ) + count( $obj->getProperties() ) + count( $obj->getConstants() ) ) === 0 ) {
-						// No methods, properties or constants found.
-						$value = null;
-					}
-				}
-				else {
-					// PHP4
-					$methods    = get_class_methods( $value );
-					$properties = get_object_vars( $value );
-					if ( ( is_null( $methods ) || count( get_class_methods( $value ) ) === 0 ) && ( is_null( $properties ) || count( get_class_methods( $properties ) ) === 0 ) ) {
-						// No methods or properties found.
-						$value = null;
-					}
+				$methods    = get_class_methods( $value );
+				$properties = get_object_vars( $value );
+				if ( ( is_null( $methods ) || count( $methods ) === 0 ) && ( is_null( $properties ) || count( $properties ) === 0 ) ) {
+					// No methods or properties found.
+					$value = null;
 				}
 			}
 

--- a/class.cast-to-type.php
+++ b/class.cast-to-type.php
@@ -428,7 +428,7 @@ if ( ! class_exists( 'CastToType' ) ) {
 			}
 
 			if ( $allow_empty === false ) {
-				if ( version_compare( PHP_VERSION, '5.0.0', '>=' ) === true ) {
+				if ( PHP_VERSION_ID > 50200 ) {
 					$obj = new ReflectionObject( $value );
 					if ( ( count( $obj->getMethods() ) + count( $obj->getProperties() ) + count( $obj->getConstants() ) ) === 0 ) {
 						// No methods, properties or constants found.
@@ -436,10 +436,10 @@ if ( ! class_exists( 'CastToType' ) ) {
 					}
 				}
 				else {
-					// PHP4
+					// PHP <= 5.1
 					$methods    = get_class_methods( $value );
 					$properties = get_object_vars( $value );
-					if ( ( is_null( $methods ) || count( get_class_methods( $value ) ) === 0 ) && ( is_null( $properties ) || count( get_class_methods( $properties ) ) === 0 ) ) {
+					if ( ( is_null( $methods ) || count( $methods ) === 0 ) && ( is_null( $properties ) || count( $properties ) === 0 ) ) {
 						// No methods or properties found.
 						$value = null;
 					}


### PR DESCRIPTION
Fixed a bug in the object casting which would return `null` for non-objects cast to objects in PHP <= 5.1.
