### PR TITLE
 Travis: More stable solution for removing Xdebug when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,15 +67,7 @@ before_script:
 script:
     # Search for PHP syntax errors.
     - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    # WordPress Coding Standards.
-    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
-    # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
+    # Check Coding Standards.
     - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the composer.json file.
     # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
 # Failures in this section will result in build status 'errored'.
 before_script:
     # Speed up build time by disabling Xdebug when its not needed.
-    - if [[ $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+    - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     # Set up temporary paths.
     - export PHPCS_DIR=/tmp/phpcs
     - export WPCS_DIR=/tmp/wpcs


### PR DESCRIPTION
Building onto https://github.com/jrfnl/PHP-cast-to-type/pull/11/commits/2fe271ecb6ac01c9ed2e7aedc094337c167872c8

As per https://twitter.com/kelunik/status/954242454676475904

When newer images of PHP versions become available, Xdebug isn't always installed.
Using this little titbit, the builds won't break because of it.