### PR TITLE
QA update

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -13,6 +13,12 @@
 	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>
 
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
+
 	<!-- Check all files in this directory and the directories below it. -->
 	<file>.</file>
 
@@ -37,8 +43,9 @@
 		<exclude name="WordPress.PHP.YodaConditions"/>
 
 		<!-- WP specific sniffs which should be ignored. -->
+		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.VIP"/>
-		<exclude name="WordPress.XSS.EscapeOutput"/>
+		<exclude name="WordPress.WP"/>
 
 		<!-- Allow the method names to be the same across classes and compatible with both PHP 4 and 5+. -->
 		<exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
@@ -48,6 +55,11 @@
 		<properties>
 			<property name="strict_class_file_names" value="false"/>
 		</properties>
+	</rule>
+
+	<!-- PHP 4 -->
+	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
+		<exclude-pattern>*/class.cast-to-type-php4\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ php:
   - 7.0
   - 7.2
   - nightly
-  - hhvm
 
 # Add some more builds which need additional settings.
 matrix:
@@ -37,7 +36,6 @@ matrix:
 
   allow_failures:
     - php: 'nightly'
-    - php: 'hhvm'
 
 
 # Use this to prepare your build for testing.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ sudo: false
 
 dist: trusty
 
+cache:
+  directories:
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
+
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
@@ -47,15 +54,8 @@ before_script:
     - export PHPCS_DIR=/tmp/phpcs
     - export WPCS_DIR=/tmp/wpcs
     - export PHPCOMPAT_DIR=/tmp/phpcompatibility
-    # Install CodeSniffer for WordPress Coding Standards checks.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-    # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-    # Install PHPCompatibility Sniffs.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
-    # Set install path for PHPCS sniffs.
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
+    # Install PHP_CodeSniffer and external standards.
+    - if [[ "$SNIFF" == "1" ]]; then composer install; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 
@@ -66,7 +66,7 @@ script:
     # Search for PHP syntax errors.
     - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     # Check Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
+    - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
     # Validate the composer.json file.
     # @link https://getcomposer.org/doc/03-cli.md#validate
     - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then composer validate --no-check-all; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - 7.2
+  - 7.1
   - nightly
 
 # Add some more builds which need additional settings.
@@ -37,8 +37,8 @@ matrix:
     # aliased to 5.3.29
     - php: '5.3'
       dist: precise
-    # aliased to a recent 7.1.x version
-    - php: '7.1'
+    # aliased to a recent 7.2.x version
+    - php: '7.2'
       env: SNIFF=1
 
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         "php": ">=5.0"
     },
     "require-dev" : {
-        "squizlabs/php_codesniffer" : "^3.2.0",
-        "wimg/php-compatibility": "^8.1.0",
+        "squizlabs/php_codesniffer" : "^3.3.0",
+        "phpcompatibility/php-compatibility": "^8.2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-        "wp-coding-standards/wpcs": "^0.14.0"
+        "wp-coding-standards/wpcs": "^1.0.0"
     },
     "autoload": {
         "files": ["class.cast-to-type.php"]


### PR DESCRIPTION
### TravisCI: drop testing on HHVM

### TravisCI: install dev dependencies using Composer

### CS: update composer and the ruleset for newly released versions of the CS standards

* PHP_CodeSniffer has released a few new versions since the last update.
    - Start using the PHPCS 3.x `basepath` and `parallel` options.
* PHPCompatibility has moved to its own organisation & released a new version `8.2.0`.
* WPCS has released a new version - `1.0.0`.
    - Update WP specific exclusions.
    - Exclude on error for a specific file.
* Test CS on PHP 7.2

