### PR TITLE
Add support for "double" alias of float

### DIFF
--- a/class.cast-to-type-php4.php
+++ b/class.cast-to-type-php4.php
@@ -73,6 +73,7 @@ if ( ! class_exists( 'CastToType' ) ) {
 				'boolean' => 1,
 				'int'     => 1,
 				'integer' => 1,
+				'double'  => 1,
 				'float'   => 1,
 				'num'     => 1,
 				'string'  => 1,
@@ -94,6 +95,7 @@ if ( ! class_exists( 'CastToType' ) ) {
 				case 'int':
 					return CastToType::_int( $value, $array2null, $allow_empty );
 
+				case 'double':
 				case 'float':
 					return CastToType::_float( $value, $array2null, $allow_empty );
 

--- a/class.cast-to-type.php
+++ b/class.cast-to-type.php
@@ -72,6 +72,7 @@ if ( ! class_exists( 'CastToType' ) ) {
 				'boolean' => 1,
 				'int'     => 1,
 				'integer' => 1,
+				'double'  => 1,
 				'float'   => 1,
 				'num'     => 1,
 				'string'  => 1,
@@ -93,6 +94,7 @@ if ( ! class_exists( 'CastToType' ) ) {
 				case 'int':
 					return self::_int( $value, $array2null, $allow_empty );
 
+				case 'double':
 				case 'float':
 					return self::_float( $value, $array2null, $allow_empty );
 


### PR DESCRIPTION
Very simple change, just added support for casting floats using the type name "double" in the `cast` method. See issue https://github.com/jrfnl/PHP-cast-to-type/issues/16.