### PR TITLE
GH Actions/dev env: minor tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,11 +7,8 @@
 #
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.phpcs.xml export-ignore
 /.phpcs.xml.dist export-ignore
-/phpcs.xml export-ignore
 /phpcs.xml.dist export-ignore
-/phpunit.xml export-ignore
 /phpunit.xml.dist export-ignore
 /.github export-ignore
 /tests export-ignore

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -39,8 +39,9 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: composer checkcs -- --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies - normal
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM-DD.


### PR DESCRIPTION
### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.

### GH Actions: minor docs fix

### .gitattributes: minor clean up