### PR TITLE
GH Actions: add PHP 8.3 to the matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,11 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
 
     name: "Lint: PHP ${{ matrix.php }}"
+
+    continue-on-error: ${{ matrix.php == '8.3' }}"
 
     steps:
       - name: Checkout code
@@ -57,8 +59,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr


### PR DESCRIPTION
PHP 8.2 has been released today and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix for linting.

Builds against PHP 8.3 are still allowed to fail for now.

Includes minor tweak to simplify the cache busting for the composer-install action.